### PR TITLE
Update script to get ignored BSPs from travis.yml

### DIFF
--- a/test_build_blinky.sh
+++ b/test_build_blinky.sh
@@ -17,59 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-declare -a bsps_arr=(
-"ada_feather_nrf52"
-"apollo2_evb"
-"arduino_primo_nrf52"
-"bbc_microbit"
-"ble400"
-"bmd200"
-"bmd300eval"
-"calliope_mini"
-# "ci40"  # required 'mips-mti-elf-gcc'
-"dwm1001-dev"
-# "embarc_emsk" # required 'arc-elf32-gcc'
-"fanstel-ev-bt840"
-"frdm-k64f"
-# "hifive1" # required 'riscv64-unknown-elf-gcc'
-"native"
-# "native-armv7" # build error
-# "native-mips" # required 'mips-mti-linux-gnu-gcc'
-"nina-b1"
-"nrf51-arduino_101"
-"nrf51-blenano"
-"nrf51dk"
-"nrf51dk-16kbram"
-"nrf52840pdk"
-"nrf52dk"
-"nrf52-thingy"
-"nucleo-f303k8"
-"nucleo-f303re"
-"nucleo-f401re"
-"nucleo-f413zh"
-"nucleo-f746zg"
-"nucleo-f767zi"
-"nucleo-l476rg"
-"olimex-p103"
-"olimex_stm32-e407_devboard"
-# "pic32mx470_6lp_clicker" # required 'xc32-gcc'
-# "pic32mz2048_wi-fire" # required 'xc32-gcc'
-"puckjs"
-"rb-blend2"
-"rb-nano2"
-"ruuvi_tag_revb2"
-# "sensorhub" # build error
-"stm32f3discovery"
-"stm32f429discovery"
-"stm32f4discovery"
-"stm32f7discovery"
-"stm32l152discovery"
-"telee02"
-# "usbmkw41z" # build error
-"vbluno51"
-"vbluno52"
-)
-
 MASTER_ZIP="master.zip"
 BLINKY_URL="https://github.com/apache/mynewt-blinky/archive"
 
@@ -83,8 +30,14 @@ ln -s "$HOME/mynewt-blinky-master/apps/blinky" apps/blinky
 
 EXIT_CODE=0
 
-for bsp in "${bsps_arr[@]}"
-do
+BSPS="$(ls ${TRAVIS_BUILD_DIR}/hw/bsp)"
+
+for bsp in ${BSPS}; do
+    if [[ "${IGNORED_BSPS}" =~ .*${bsp}.* ]]; then
+        echo "Skipping \"${bsp}\""
+        continue
+    fi
+
     echo "Testing bsp=$bsp"
 
     target="test-blinky-$bsp"


### PR DESCRIPTION
This allows IGNORED_BSPS to be configured on travis.yml to automatically ignore BSPs known to fail on build. The list of BSPs is automatically loaded from the "hw/bsp" so that new BSPs are already on by default and to ignore them it is not required to change this repo (only need to add to IGNORED_BSPS in .travis.yml from mynewt-core).

This depends on #3 being merged first. It goes together with https://github.com/apache/mynewt-core/pull/1428