### PR TITLE
Increase regex strictness for ignored BSPs checks

### DIFF
--- a/test_build_blinky.sh
+++ b/test_build_blinky.sh
@@ -29,12 +29,13 @@ unzip -q "$HOME/${MASTER_ZIP}" -d "$HOME"
 ln -s "$HOME/mynewt-blinky-master/apps/blinky" apps/blinky
 
 EXIT_CODE=0
-
 BSPS="$(ls ${TRAVIS_BUILD_DIR}/hw/bsp)"
 
 for bsp in ${BSPS}; do
-    if [[ "${IGNORED_BSPS}" =~ .*${bsp}.* ]]; then
-        echo "Skipping \"${bsp}\""
+    # NOTE: do not remove the spaces around IGNORED_BSPS; it's required to
+    #       match against the first and last entries
+    if [[ " ${IGNORED_BSPS} " =~ [[:blank:]]${bsp}[[:blank:]] ]]; then
+        echo "Skipping bsp=$bsp"
         continue
     fi
 


### PR DESCRIPTION
The current regex does invalidate running on "native" because it matches against "native-mips" and "native-armv7". This makes the regex require that the full name matches.