### PR TITLE
Remove ffs2native target

### DIFF
--- a/mynewt-core-targets/native_ffs2native/pkg.yml
+++ b/mynewt-core-targets/native_ffs2native/pkg.yml
@@ -1,6 +1,0 @@
-pkg.name: "targets/native_ffs2native"
-pkg.type: "target"
-pkg.description: 
-pkg.author: 
-pkg.homepage: 
-

--- a/mynewt-core-targets/native_ffs2native/target.yml
+++ b/mynewt-core-targets/native_ffs2native/target.yml
@@ -1,2 +1,0 @@
-target.app: "@apache-mynewt-core/apps/ffs2native"
-target.bsp: "@apache-mynewt-core/hw/bsp/native"


### PR DESCRIPTION
This was the only target that required gcc-multilib, and removing it allows faster builds on the build targets machines by removing the gcc-multilib dependency.