### PR TITLE
Add support scripts to allow parallel tests

### DIFF
--- a/linux_toolchain_install.sh
+++ b/linux_toolchain_install.sh
@@ -32,6 +32,3 @@ for i in ${TOOLCHAIN_PATH}/${GCC_BASE}/bin/arm-none-eabi-* ; do
     rm -f  ~/bin/${i##*/}
     ln -s $i ~/bin/${i##*/}
 done
-
-ln -s /usr/bin/gcc-7 ~/bin/gcc
-ln -s /usr/bin/g++-7 ~/bin/g++

--- a/prepare_test.sh
+++ b/prepare_test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+###############################################################################
+
+# Breaks the list of tests to run into multiple sets to be delivered to
+# multiple machines.
+
+# Expects a parameter that is the amount of machines that will be running
+# the given set of tests, and an environment variable $TARGET_SET that
+# should be a machine index from 1 to N amount of machines.
+
+# NOTE: $target_list must store the targets to run in sorted order, because
+#       breaking targets into sets require a predictable order so that each
+#       machine ends up with a list of tests that is different from all the
+#       others that are running the same test.
+
+TOTAL_SETS=$1
+
+case $TEST in
+  "TEST_ALL")
+    target_list=$(find ${TRAVIS_BUILD_DIR} -iname pkg.yml -exec grep -H "pkg\.type: *unittest" {} \; | cut -d: -f1 | sed s#/pkg.yml##g | sed s#^${TRAVIS_BUILD_DIR}/##g | grep -v "^repos/" | sort)
+    ;;
+  "BUILD_TARGETS")
+    target_list=$(ls targets/mynewt-core-targets)
+    ;;
+  "BUILD_BLINKY")
+    target_list=$(ls ${TRAVIS_BUILD_DIR}/hw/bsp)
+    ;;
+  "BUILD_PORTS")
+    # don't need to do anything here
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+
+total_targets=$(echo "$target_list" | wc -l)
+set_size=$(echo "${total_targets} / ${TOTAL_SETS} + 1" | bc)
+set=0
+off=1
+sets=()
+while [ $set -lt $TOTAL_SETS ]; do
+  sets[$set]=$(echo "$target_list" | tail -n +$off | head -n $set_size)
+  set=$((set + 1))
+  off=$((off + set_size))
+done
+
+# Save the targets this machine will run
+echo ${sets[$((TARGET_SET - 1))]} > ${TRAVIS_BUILD_DIR}/targets.txt

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -x
+#!/bin/bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,14 +20,11 @@
 rc=0
 case $TEST in
   "TEST_ALL")
-     # These tests fail on 14.04 which travis uses
-     newt test all -e net/oic/test,net/ip/mn_socket/test
+     $HOME/ci/test_all.sh
      rc=$?
      ;;
   "BUILD_TARGETS")
-     # Without suppressing output, travis complains that the log is too big
-     # Without output, travis terminates a job that doesn't print out anything in a few minutes
-     newt build -q -l info all
+     $HOME/ci/test_build_targets.sh
      rc=$?
      ;;
   "BUILD_BLINKY")

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,29 +17,23 @@
 # specific language governing permissions and limitations
 # under the License.
 
-echo "Doing Linux install"
+EXIT_CODE=0
 
-export GOPATH=$HOME/gopath
+TARGETS=$(cat ${TRAVIS_BUILD_DIR}/targets.txt)
+for unittest in ${TARGETS}; do
+    # TODO: ignore tests that fail on Ubuntu 14.04
+    if [ ${TRAVIS_OS_NAME} = "linux" ]; then
+        if [ "$unittest" = "net/oic/test" -o "$unittest" = "net/ip/mn_socket/test" ]; then
+            echo "Ignoring $unittest"
+            continue
+        fi
+    fi
 
-mkdir -p $HOME/bin $GOPATH || true
+    echo "Testing unittest=$unittest"
+    newt test -q $unittest
 
-go version
+    rc=$?
+    [[ $rc -ne 0 ]] && EXIT_CODE=$rc
+done
 
-go get mynewt.apache.org/newt/newt
-[[ $? -ne 0 ]] && exit 1
-
-rm -rf $GOPATH/bin $GOPATH/pkg
-
-go install mynewt.apache.org/newt/newt
-[[ $? -ne 0 ]] && exit 1
-
-cp $GOPATH/bin/newt $HOME/bin
-
-# Do not install ARM toolchain when running "newt test"
-if [ $TEST != "TEST_ALL" ]; then
-  source $HOME/ci/linux_toolchain_install.sh
-else
-  # FIXME: should use update-alternatives here maybe?
-  ln -s /usr/bin/gcc-7 ~/bin/gcc
-  ln -s /usr/bin/g++-7 ~/bin/g++
-fi
+exit $EXIT_CODE

--- a/test_build_blinky.sh
+++ b/test_build_blinky.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -29,9 +29,9 @@ unzip -q "$HOME/${MASTER_ZIP}" -d "$HOME"
 ln -s "$HOME/mynewt-blinky-master/apps/blinky" apps/blinky
 
 EXIT_CODE=0
-BSPS="$(ls ${TRAVIS_BUILD_DIR}/hw/bsp)"
 
-for bsp in ${BSPS}; do
+TARGETS=$(cat ${TRAVIS_BUILD_DIR}/targets.txt)
+for bsp in ${TARGETS}; do
     # NOTE: do not remove the spaces around IGNORED_BSPS; it's required to
     #       match against the first and last entries
     if [[ " ${IGNORED_BSPS} " =~ [[:blank:]]${bsp}[[:blank:]] ]]; then

--- a/test_build_targets.sh
+++ b/test_build_targets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,29 +17,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-echo "Doing Linux install"
+EXIT_CODE=0
 
-export GOPATH=$HOME/gopath
+TARGETS=$(cat ${TRAVIS_BUILD_DIR}/targets.txt)
+for target in ${TARGETS}; do
+    echo "Building target=$target"
 
-mkdir -p $HOME/bin $GOPATH || true
+    # Without suppressing output, travis complains that the log is too big
+    # Without output, travis terminates a job that doesn't print out anything in a few minutes
+    newt build -q -l info $target
 
-go version
+    rc=$?
+    [[ $rc -ne 0 ]] && EXIT_CODE=$rc
+done
 
-go get mynewt.apache.org/newt/newt
-[[ $? -ne 0 ]] && exit 1
-
-rm -rf $GOPATH/bin $GOPATH/pkg
-
-go install mynewt.apache.org/newt/newt
-[[ $? -ne 0 ]] && exit 1
-
-cp $GOPATH/bin/newt $HOME/bin
-
-# Do not install ARM toolchain when running "newt test"
-if [ $TEST != "TEST_ALL" ]; then
-  source $HOME/ci/linux_toolchain_install.sh
-else
-  # FIXME: should use update-alternatives here maybe?
-  ln -s /usr/bin/gcc-7 ~/bin/gcc
-  ln -s /usr/bin/g++-7 ~/bin/g++
-fi
+exit $EXIT_CODE


### PR DESCRIPTION
This enables updating the repo's build matrix adding multiple machines to a pool for some test. Adding new machines requires setting `$VM_AMOUNT` to the total amount of VMs for some `$TEST` and each machine should also set an env variable `$TARGET_SET` with an index from 1 to `$VM_AMOUNT`.

Also add a few other small fixes for osx build setup.