### PR TITLE
Get amounts from map size; don't fail on new files

### DIFF
--- a/mynewt-rat-json.xsl
+++ b/mynewt-rat-json.xsl
@@ -22,14 +22,13 @@
 <xsl:output method='text'/>
 <xsl:template match='/'>{
   "timestamp": "<xsl:value-of select='rat-report/@timestamp' />",
-  <xsl:if test="descendant::resource[license-approval/@name='false']">"unknown_amount": "<xsl:value-of select='count(descendant::header-type[attribute::name="?????"])' />",
-  "unknown": [<xsl:for-each select='descendant::resource[license-approval/@name="false"]'>
+  <xsl:if test="descendant::resource[license-approval/@name='false']">"unknown": [<xsl:for-each
+          select='descendant::resource[license-approval/@name="false"]'>
     {
       "name": "<xsl:value-of select='@name'/>"
     }<xsl:if test="position() != last()">,</xsl:if>
   </xsl:for-each>
   ],</xsl:if>
-  "files_amount": "<xsl:value-of select='count(descendant::resource)' />",
   "files": [<xsl:for-each select='descendant::resource'>
     {
       "name": "<xsl:value-of select='@name'/>",


### PR DESCRIPTION
The JSON XSLT was updated to not output "unknown_amount" and "files_amount". Those sizes are better determined by checking the len of the dicts in Python.

The existence of new files with unknown licenses was failing the check and was disabled for now. Now this check only fails, if there was a communication error with the endpoints (or GH).